### PR TITLE
[fix] valinor-export-graph: use u8::overflowing_sub for subtracting discriminants 

### DIFF
--- a/valinor-export-graph/src/models.rs
+++ b/valinor-export-graph/src/models.rs
@@ -18,7 +18,7 @@ impl From<(&TileLevel, bool, RoadClass)> for Tippecanoe {
             min_zoom: std::cmp::min(
                 12,
                 level.tiling_system.min_zoom()
-                    + match &level.minimum_road_class.discriminant() - road_class.discriminant() {
+                    + match u8::overflowing_sub(level.minimum_road_class.discriminant(), road_class.discriminant()).0 {
                         0 => 2,
                         1 => 1,
                         2.. => 0,


### PR DESCRIPTION
Closes #7 